### PR TITLE
feat: add execution time summary on exit

### DIFF
--- a/pingt/ConsoleDisplay.cs
+++ b/pingt/ConsoleDisplay.cs
@@ -41,9 +41,16 @@ namespace pingt
             WriteError($"{DateTime.Now:yyyy-MM-dd HH:mm:ss} - ERROR: {message}");
         }
 
-        public static void DisplayStatistics(PingStatistics stats)
+        public static void DisplayStatistics(PingStatistics stats, DateTime startTime, DateTime endTime)
         {
+            TimeSpan elapsed = endTime - startTime;
+
             Console.WriteLine();
+            Console.WriteLine(new string('=', 80));
+            Console.WriteLine($"{endTime:yyyy-MM-dd HH:mm:ss} - Session ended");
+            Console.WriteLine($"Start: {startTime:yyyy-MM-dd HH:mm:ss}  |  " +
+                            $"End: {endTime:yyyy-MM-dd HH:mm:ss}  |  " +
+                            $"Duration: {(int)elapsed.TotalHours:D2}:{elapsed.Minutes:D2}:{elapsed.Seconds:D2}");
             Console.WriteLine(new string('=', 80));
             WriteSuccess($"Ping Statistics: {stats}");
             Console.WriteLine(new string('=', 80));

--- a/pingt/Program.cs
+++ b/pingt/Program.cs
@@ -15,6 +15,7 @@ namespace pingt
         {
             string host = ParseHost(args);
             var cts = new CancellationTokenSource();
+            var startTime = DateTime.Now;
 
             // Handle Ctrl+C gracefully
             Console.CancelKeyPress += (sender, e) =>
@@ -50,7 +51,7 @@ namespace pingt
                 }
                 finally
                 {
-                    ConsoleDisplay.DisplayStatistics(stats);
+                    ConsoleDisplay.DisplayStatistics(stats, startTime, DateTime.Now);
                 }
             }
         }


### PR DESCRIPTION
Displays start time, end time and total duration before ping statistics when the user presses CTRL+C.